### PR TITLE
Improve conversion api

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "sirv-cli": "1.0.3"
   },
   "dependencies": {
-    "@neslinesli93/mozjpeg-wasm": "^1.0.2",
+    "@neslinesli93/mozjpeg-wasm": "^1.0.3",
     "classnames": "^2.2.6",
     "file-saver": "^2.0.5",
     "jszip": "^3.5.0",

--- a/src/converter/wasm.worker.js
+++ b/src/converter/wasm.worker.js
@@ -29,7 +29,6 @@ export class JpegConverter {
     // 1) [New] Returns a struct with two u32 fields: pointer and size
     // 2) [Deprecated] Returns a string with "pointer|size"
     try {
-      console.log("new convert");
       const convert = this.Module.cwrap("new_convert", "number", [
         "number",
         "number",
@@ -50,7 +49,6 @@ export class JpegConverter {
 
       return { resultData, resultSize };
     } catch (error) {
-      console.log("old convert");
       const convert = this.Module.cwrap("convert", "string", [
         "number",
         "number",

--- a/src/converter/wasm.worker.js
+++ b/src/converter/wasm.worker.js
@@ -25,41 +25,51 @@ export class JpegConverter {
     );
     this.Module.HEAPU8.set(input, inputBuffer);
 
-    const convert = this.Module.cwrap("convert", "number", [
-      "number",
-      "number",
-      "number",
-      "number",
-    ]);
-    const result = convert(inputBuffer, input.length, quality, orientation);
-    let resultData = null;
-    let resultSize = null;
-
     // Deal with possibly different versions of the WASM module:
-    // 1) [Deprecated] Returns a string with "pointer|size"
-    // 2) [New] Returns a struct with two u32 fields: pointer and size
-    if (typeof result === "string") {
-      const splitted = result.split("|");
-      const outputBuffer = parseInt(splitted[0], 16);
-      resultSize = parseInt(splitted[1], 10);
+    // 1) [New] Returns a struct with two u32 fields: pointer and size
+    // 2) [Deprecated] Returns a string with "pointer|size"
+    try {
+      console.log("new convert");
+      const convert = this.Module.cwrap("new_convert", "number", [
+        "number",
+        "number",
+        "number",
+        "number",
+      ]);
+      const result = convert(inputBuffer, input.length, quality, orientation);
 
-      resultData = new Uint8Array(
-        this.Module.HEAPU8.subarray(outputBuffer, outputBuffer + resultSize)
-      );
-
-      this.Module._free(inputBuffer);
-    } else {
       const outputBuffer = this.Module.HEAPU32[result / 4];
-      resultSize = this.Module.HEAPU32[result / 4 + 1];
+      const resultSize = this.Module.HEAPU32[result / 4 + 1];
 
-      resultData = new Uint8Array(
+      const resultData = new Uint8Array(
         this.Module.HEAPU8.subarray(outputBuffer, outputBuffer + resultSize)
       );
 
       this.Module._free(inputBuffer);
       this.Module._free(outputBuffer);
-    }
 
-    return { resultData, resultSize };
+      return { resultData, resultSize };
+    } catch (error) {
+      console.log("old convert");
+      const convert = this.Module.cwrap("convert", "string", [
+        "number",
+        "number",
+        "number",
+        "number",
+      ]);
+      const result = convert(inputBuffer, input.length, quality, orientation);
+
+      const splitted = result.split("|");
+      const outputBuffer = parseInt(splitted[0], 16);
+      const resultSize = parseInt(splitted[1], 10);
+
+      const resultData = new Uint8Array(
+        this.Module.HEAPU8.subarray(outputBuffer, outputBuffer + resultSize)
+      );
+
+      this.Module._free(inputBuffer);
+
+      return { resultData, resultSize };
+    }
   }
 }

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -85,6 +85,8 @@ const Main = ({ title, canRender, initError }) => {
             );
           })
           .catch((err) => {
+            console.error(err);
+
             setFiles((prev) =>
               prev.map((f) => {
                 if (f.id === file.id) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1091,10 +1091,10 @@
   dependencies:
     extend "3.0.2"
 
-"@neslinesli93/mozjpeg-wasm@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@neslinesli93/mozjpeg-wasm/-/mozjpeg-wasm-1.0.2.tgz#68aefbfb99d4af3651dfae0a0a7f6d0a74a08652"
-  integrity sha512-nl/s3lOLTDjMSNZ1D89A2uUU5I83PgLQIQw3Kg7UMEGnScAMwzy3BR7ZKvXXOQNeN+s1VfHaLBHLZYciweGbsw==
+"@neslinesli93/mozjpeg-wasm@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@neslinesli93/mozjpeg-wasm/-/mozjpeg-wasm-1.0.3.tgz#71cf1354cd7416ad12800ced19770632162e07e6"
+  integrity sha512-qfkHA+MPv3SBwz7xp+SKlwAM9kjmrHTRjIDdfMLECG9BVPkhKSgm6Siq75ZSMcw62oB9L1KybhWdHQGDku60/Q==
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"


### PR DESCRIPTION
Bump `mozjpeg-wasm` to 1.0.3 so that `new_convert` is available. Deprecate `convert` since it uses a string-based hack.

The old code path is still available and used as a fallback mechanism for clients that still have the WASM module in cache